### PR TITLE
Add TelemetryDeck analytics and a privacy policy page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,5 @@ Pushing to `main` automatically builds and deploys to GitHub Pages via the GitHu
 ## TODO
 
 - Expand the light/dark mode toggle to include an "auto" mode that follows `prefers-color-scheme`.
+- GitHub badge
+- Auto-updating changelogs

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -29,9 +29,11 @@ title: Ibrahim Al-Alali
         document.createElement('nav'); 
         </script>
         <![endif]-->
-        <!-- Analytics 
-        <script defer data-domain="corbin.io" src="https://plausible.io/js/plausible.js"></script>
-        -->
+        <!-- Analytics: TelemetryDeck -->
+        <script
+            src="https://cdn.telemetrydeck.com/websdk/telemetrydeck.min.js"
+            data-app-id="2D083718-D442-4A8E-B797-68F24ADD0C7E"
+        ></script>
         <!-- Open Graph card -->
         <meta property="og:type" content="website" />
         <meta property="og:title" content="{{ title }}" />
@@ -53,6 +55,9 @@ title: Ibrahim Al-Alali
                 </li>
                 <li>
                     {% if page.url == "/contact/" %}<span class="nav-current">Contact</span>{% else %}<a href="/contact">Contact</a>{% endif %}
+                </li>
+                <li>
+                    {% if page.url == "/privacy/" %}<span class="nav-current">Privacy</span>{% else %}<a href="/privacy">Privacy</a>{% endif %}
                 </li>
             </ul>
         </nav>

--- a/privacy.md
+++ b/privacy.md
@@ -1,0 +1,25 @@
+---
+layout: main_layout.njk
+title: Privacy Policy
+---
+
+<div class="contact-hero">
+<h1 class="contact-title">Privacy Policy</h1>
+<p class="contact-subtitle">Last updated: 2026-04-25</p>
+</div>
+
+This site does **not** use cookies and does **not** collect any personal information. No accounts, no tracking across sites, no advertising.
+
+{% heading "Analytics", "analytics" %}
+
+Anonymous usage analytics are collected via [TelemetryDeck](https://telemetrydeck.com) so I can see how many people visit and which pages are popular. **No personal information** (PII) is sent. TelemetryDeck does not use cookies or browser fingerprinting; visitors are identified by a hash derived from IP address, user agent, app ID, and a daily-rotating salt. The hash cannot be reversed and changes every day.
+
+See [TelemetryDeck's privacy FAQ](https://telemetrydeck.com/docs/guides/privacy-faq/) for full details.
+
+{% heading "Hosting", "hosting" %}
+
+This site is hosted on GitHub Pages. GitHub may log standard request metadata (such as IP address and user agent) for security and operational purposes. See [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) for details.
+
+{% heading "Contact", "contact" %}
+
+Questions about this policy? [Get in touch](/contact).


### PR DESCRIPTION
Wire the TelemetryDeck web SDK into the shared layout so every page reports anonymous pageviews. Add a dedicated /privacy/ page describing what is collected and add it to the nav. Append GitHub badge and auto-updating changelog ideas to the README TODO list.