### PR TITLE
Split per-app privacy policies into dedicated pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,8 @@ There are no test or lint scripts configured.
 - **Static site generator:** Eleventy with Nunjucks templates and Markdown content
 - **Layouts:** `_includes/main_layout.njk` is the base HTML template with nav. `_includes/app_layout.njk` chains onto it for app detail pages, rendering a hero (icon, name, tagline, Play Store CTA) from frontmatter before the markdown body.
 - **Content pages:** Top-level `.md` files (`index.md`, `about.md`, `contact.md`, `privacy.md`, `404.md`)
-- **App detail pages:** `app/*.md` — use `app_layout.njk` and declare `appName`, `icon`, `packageName`, `tagline`, and `title` in frontmatter. Optional `repoUrl` adds a "View source on GitHub" badge in the hero. Body holds the What's New callout, changelog, and privacy policy.
+- **App detail pages:** `app/*.md` — use `app_layout.njk` and declare `appName`, `icon`, `packageName`, `tagline`, and `title` in frontmatter. Optional `repoUrl` adds a "View source on GitHub" badge in the hero. Body holds the What's New callout, changelog, and a short "Privacy Policy" section that links to the per-app privacy page.
+- **Per-app privacy pages:** `app/<slug>/privacy.md` — each app has its own privacy policy at a dedicated URL (e.g. `/app/hide_persistent_notification/privacy/`). They use `main_layout.njk` with a `contact-hero` header and an `app-back-link` to the app page. Required because Google Play Console rejects a privacy URL that shares its path with the store listing URL (a `#fragment` on the app page resolves server-side to the same URL and is rejected).
 - **Styling:** Single stylesheet at `media/styles.css`
 - **Client JS:** `main.js` — opens external links in new tabs, handles a three-mode (light → dark → auto) theme toggle with tooltip and localStorage persistence, and fires the `App.Referral` TelemetryDeck signal for sessions that landed via `?utm_source=android_app`
 - **Static assets:** `media/` — images, icons, CSS (passed through via Eleventy config)

--- a/app/basic_root_checker.md
+++ b/app/basic_root_checker.md
@@ -16,16 +16,26 @@ This app does **NOT** collect any data or personal information.
 This app is not endorsed by or affiliated with _topjohnwu_ or _libsu_
 
 {% whatsNew %}
-Complete rewrite with modern technologies
+- Detects which root provider (Magisk, KernelSU, APatch) granted root, with Magisk version
+- "Request Root access" button when a provider is present but not yet granted
+- Support for Android 17
 {% endwhatsNew %}
 
 
 ## Changelog
+### Version 2.1:
+* ➕ Root provider detection: Magisk (with version), KernelSU, or APatch
+* ➕ "Request Root access" button when a provider is present but not yet granted
+* ➕ Support for Android 17
+* 🛠️ New "Not granted" state when a root provider is detected but access isn't given yet
+* 🔨 Fixed rooted devices being reported as not rooted on the first check
+
 ### Version 2.0:
-* ➕ Complete rewrite with Jetpack Compose
-* ➕ Added support for changing the apps language independent of the systems (Android 15 and up)
-* 🛠️ Dropped support for Android 5.0 and 5.1, new minimum is 6.0
-* 🛠️ Dependency updates
+* ➕ Complete rewrite with Jetpack Compose, Material 3, and dynamic colors
+* ➕ TelemetryDeck analytics with an opt-out toggle in settings
+* ➕ In-app update flow on the Google Play build
+* 🛠️ Split into Google Play and FOSS flavors
+* 🛠️ Minimum version raised to Android 6.0
 
 ### Version 1.13:
 * ➕ Android 16 support
@@ -73,14 +83,6 @@ Complete rewrite with modern technologies
 ### Version 1.0:
 * ➕ Basic Root Checker comes in 3 languages: English, German and Arabic
 
-{% heading "Privacy Policy", "privacy-policy" %}
+## Privacy Policy
 
-The app _Basic Root Checker_ does **not** collect any personal information. The app itself works fully offline; anonymous usage telemetry is sent when a connection is available.
-
-A small amount of analytics is included in the app. **No personal information** (PII) is included in this telemetry. See [What data is collected by TelemetryDeck SDK for apps?](https://telemetrydeck.com/docs/guides/privacy-faq/#what-data-is-collected-by-telemetrydeck-sdk-for-apps%3F) for the defaults. In addition, the developer records:
-
-* Screen navigation within the app
-* Root check started
-* Root check completed (with result)
-* Privacy policy opened
-* Other Apps section opened
+See the [Basic Root Checker privacy policy](/app/basic_root_checker/privacy/).

--- a/app/basic_root_checker/privacy.md
+++ b/app/basic_root_checker/privacy.md
@@ -1,0 +1,26 @@
+---
+layout: main_layout.njk
+title: Basic Root Checker — Privacy Policy
+---
+
+<a href="/app/basic_root_checker/" class="app-back-link">&larr; Basic Root Checker</a>
+
+<div class="contact-hero">
+<h1 class="contact-title">Basic Root Checker</h1>
+<p class="contact-subtitle">Privacy Policy</p>
+</div>
+
+The app _Basic Root Checker_ does **not** collect any personal information. The app itself works fully offline; anonymous usage telemetry is sent when a connection is available, and it can be turned off at any time from the in-app settings.
+
+A small amount of analytics is included in the app. **No personal information** (PII) is included in this telemetry. See [What data is collected by TelemetryDeck SDK for apps?](https://telemetrydeck.com/docs/guides/privacy-faq/#what-data-is-collected-by-telemetrydeck-sdk-for-apps%3F) for the defaults. In addition, the developer records:
+
+* Screen navigation within the app
+* Root check started
+* Root check completed (with the resulting status)
+* Root access requested via the "Request Root access" button
+* Root provider detected (Magisk, KernelSU, APatch, or unknown) and its version when available
+* Privacy policy opened
+* Website link opened
+* Other Apps entry tapped (with the package name of the app that was tapped)
+* In-app update events (update available, started, downloaded, failed) on the Google Play build
+* Errors and unhandled exceptions (an internal error id, the error message, and a category such as thrown-exception, user-input, or app-state)

--- a/app/billboard.md
+++ b/app/billboard.md
@@ -51,6 +51,6 @@ Can be used in meeting to vote on a subject with a number or a text.
 * ➕ Added keyboard type options
 * ➕ Added saving orientation and keyboard options.
 
-{% heading "Privacy Policy", "privacy-policy" %}
+## Privacy Policy
 
-The app _Billboard_ does **not** collect any personal information, and does **not** need an internet connection to function, and it does not contain any analytic code.
+See the [Billboard privacy policy](/app/billboard/privacy/).

--- a/app/billboard/privacy.md
+++ b/app/billboard/privacy.md
@@ -1,0 +1,13 @@
+---
+layout: main_layout.njk
+title: Billboard — Privacy Policy
+---
+
+<a href="/app/billboard/" class="app-back-link">&larr; Billboard</a>
+
+<div class="contact-hero">
+<h1 class="contact-title">Billboard</h1>
+<p class="contact-subtitle">Privacy Policy</p>
+</div>
+
+The app _Billboard_ does **not** collect any personal information, and does **not** need an internet connection to function, and it does not contain any analytic code.

--- a/app/book_keeper.md
+++ b/app/book_keeper.md
@@ -14,6 +14,6 @@ Track your book collection
 ### Version 0.1
 Initial test release
 
-{% heading "Privacy Policy", "privacy-policy" %}
+## Privacy Policy
 
-The app _Book Keeper_ does **not** collect any personal information, and does need an internet connection to function, and it does not contain any analytic code.
+See the [Book Keeper privacy policy](/app/book_keeper/privacy/).

--- a/app/book_keeper/privacy.md
+++ b/app/book_keeper/privacy.md
@@ -1,0 +1,13 @@
+---
+layout: main_layout.njk
+title: Book Keeper — Privacy Policy
+---
+
+<a href="/app/book_keeper/" class="app-back-link">&larr; Book Keeper</a>
+
+<div class="contact-hero">
+<h1 class="contact-title">Book Keeper</h1>
+<p class="contact-subtitle">Privacy Policy</p>
+</div>
+
+The app _Book Keeper_ does **not** collect any personal information, and does need an internet connection to function, and it does not contain any analytic code.

--- a/app/hide_persistent_notification.md
+++ b/app/hide_persistent_notification.md
@@ -75,10 +75,6 @@ tagline: Pick a persistent notification and keep it hidden for as long as the ap
 ### Version 1.0.0:
 * ✨ Initial Release
 
-{% heading "Privacy Policy", "privacy-policy" %}
+## Privacy Policy
 
-The app *Hide Persistent Notifications* does **not** collect any personal information, and does **not** need an internet connection to function, and it does not contain any analytic code.
-
-The app *Hide Persistent Notifications* does **need** access to the notification on your device, but it does not do anything with the notification except for displaying it to you in the app, for you to choose if you want to hide it.
-
-The User **can choose** to log and send all currently visible notification to the developer. Before it is send to the developer, all sensitive information will be removed as best as possible, and the user can check removal process in an text editor in the app. After the User is satisfied, the user could or could not choose to send the notification data to the developer.
+See the [Hide Persistent Notification privacy policy](/app/hide_persistent_notification/privacy/).

--- a/app/hide_persistent_notification/privacy.md
+++ b/app/hide_persistent_notification/privacy.md
@@ -1,0 +1,17 @@
+---
+layout: main_layout.njk
+title: Hide Persistent Notification — Privacy Policy
+---
+
+<a href="/app/hide_persistent_notification/" class="app-back-link">&larr; Hide Persistent Notification</a>
+
+<div class="contact-hero">
+<h1 class="contact-title">Hide Persistent Notification</h1>
+<p class="contact-subtitle">Privacy Policy</p>
+</div>
+
+The app *Hide Persistent Notifications* does **not** collect any personal information, and does **not** need an internet connection to function, and it does not contain any analytic code.
+
+The app *Hide Persistent Notifications* does **need** access to the notification on your device, but it does not do anything with the notification except for displaying it to you in the app, for you to choose if you want to hide it.
+
+The User **can choose** to log and send all currently visible notification to the developer. Before it is send to the developer, all sensitive information will be removed as best as possible, and the user can check removal process in an text editor in the app. After the User is satisfied, the user could or could not choose to send the notification data to the developer.


### PR DESCRIPTION
Google Play Console rejects privacy URLs that share their path with the store-listing URL (a #fragment on the app page resolves server-side to the same URL). Each app now has its own privacy page at /app/<slug>/privacy/, and the app body links to it instead of inlining the section.

Also refreshes the Basic Root Checker 2.0 and 2.1 changelog entries and privacy policy to match the current source CHANGELOG and Analytics.kt signals (root provider detection, request-root, update flow, error telemetry).