### PR TITLE
Add a warm 'Paper' theme to the toggle cycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ npx @11ty/eleventy --serve   # Local dev server with hot reload
 
 There are no test or lint scripts configured.
 
+**Termux quirk:** `npx @11ty/eleventy` fails with `eleventy: not found` because the `node_modules/.bin` wrappers use a `#!/usr/bin/env` shebang, and `/usr/bin/env` doesn't exist on Termux. Workarounds: invoke via node directly (`node ./node_modules/.bin/eleventy --serve`) or run `termux-fix-shebang node_modules/.bin/*` once after `npm install`.
+
 ## Architecture
 
 - **Static site generator:** Eleventy with Nunjucks templates and Markdown content

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -17,7 +17,7 @@ title: Ibrahim Al-Alali
         <script>
             (function() {
                 var t = localStorage.getItem('theme');
-                if (t === 'light' || t === 'dark') document.documentElement.setAttribute('data-theme', t);
+                if (t === 'light' || t === 'dark' || t === 'paper') document.documentElement.setAttribute('data-theme', t);
             })();
         </script>
         <link rel="icon" type="image/png" href="/media/icon_x32.png" sizes="32x32">

--- a/main.js
+++ b/main.js
@@ -7,27 +7,30 @@ document.querySelectorAll('main a').forEach(function (linkEl) {
     }
 })
 
-// Theme toggle: cycles light -> dark -> auto
+// Theme toggle: cycles light -> dark -> paper -> auto
 ;(function () {
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var tooltip = document.getElementById('theme-toggle-tooltip');
     var tooltipTimer;
 
-    var modes = ['light', 'dark', 'auto'];
+    var modes = ['light', 'dark', 'paper', 'auto'];
     var icons = {
         light: '☀️',                  // sun
         dark: '🌙',                   // crescent moon
+        paper: '📖',                  // open book
         auto: '🖥️'              // desktop computer
     };
     var labels = {
         light: 'Theme: light. Click to switch to dark.',
-        dark: 'Theme: dark. Click to switch to auto.',
+        dark: 'Theme: dark. Click to switch to paper.',
+        paper: 'Theme: paper. Click to switch to auto.',
         auto: 'Theme: auto (matches system). Click to switch to light.'
     };
     var tooltipText = {
         light: 'Light',
         dark: 'Dark',
+        paper: 'Paper',
         auto: 'Auto (matches system)'
     };
 

--- a/media/styles.css
+++ b/media/styles.css
@@ -63,6 +63,22 @@
     --muted: #999;
 }
 
+:root[data-theme="paper"] {
+    --bg: #F4F1EA;            /* warm paper */
+    --text: #1A1A1A;          /* near-black ink */
+    --text-on-accent: #F4F1EA;
+    --accent: #3A3A3A;        /* dark ink instead of color */
+    --accent-hover: #555555;
+    --link-hover: #000000;
+    --border: #C9C2B3;        /* warm gray */
+    --icon-bg: #EAE6DC;
+    --shadow-accent: transparent;
+    --shadow-accent-strong: transparent;
+    --shadow-accent-glow: transparent;
+    --shadow-accent-tint: transparent;
+    --muted: #6B655B;
+}
+
 /* Main styles */
 
 html {
@@ -913,6 +929,21 @@ a.btn-container img:hover {
         bottom: 68px;
         right: 16px;
     }
+}
+
+/* Paper: flatten glows and motion, and render imagery monochrome for a paper-like feel */
+
+:root[data-theme="paper"] *,
+:root[data-theme="paper"] *::before,
+:root[data-theme="paper"] *::after {
+    box-shadow: none !important;
+    text-shadow: none !important;
+    animation: none !important;
+    transition: none !important;
+}
+
+:root[data-theme="paper"] img {
+    filter: grayscale(1);
 }
 
 /* Disable animations on user request */


### PR DESCRIPTION
Adds a fourth theme mode (light → dark → paper → auto) that evokes an
e-reader / printed page: a warm-paper background with near-black ink text.
The mode flattens colored glows/shadows and disables animations and
transitions while active, and renders imagery (profile photo, app icons)
in grayscale for a monochrome, paper-like feel.

Named 'Paper' rather than 'e-ink' to avoid the 'E Ink' trademark.