### PR TITLE
Add shared-element view transition for the app icon

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ There are no test or lint scripts configured.
 - **App detail pages:** `app/*.md` — use `app_layout.njk` and declare `appName`, `icon`, `packageName`, `tagline`, and `title` in frontmatter. Optional `repoUrl` adds a "View source on GitHub" badge in the hero. Body holds the What's New callout, changelog, and a short "Privacy Policy" section that links to the per-app privacy page.
 - **Per-app privacy pages:** `app/<slug>/privacy.md` — each app has its own privacy policy at a dedicated URL (e.g. `/app/hide_persistent_notification/privacy/`). They use `main_layout.njk` with a `contact-hero` header and an `app-back-link` to the app page. Required because Google Play Console rejects a privacy URL that shares its path with the store listing URL (a `#fragment` on the app page resolves server-side to the same URL and is rejected).
 - **Styling:** Single stylesheet at `media/styles.css`
-- **Client JS:** `main.js` — opens external links in new tabs, handles a three-mode (light → dark → auto) theme toggle with tooltip and localStorage persistence, and fires the `App.Referral` TelemetryDeck signal for sessions that landed via `?utm_source=android_app`
+- **Client JS:** `main.js` — opens external links in new tabs, handles a four-mode (light → dark → paper → auto) theme toggle with tooltip and localStorage persistence, fires the `App.Referral` TelemetryDeck signal for sessions that landed via `?utm_source=android_app`, and tags the navigating home-page app icon for the shared-element view transition (see below)
 - **Static assets:** `media/` — images, icons, CSS (passed through via Eleventy config)
 - **Analytics:** TelemetryDeck Web SDK loaded in `_includes/main_layout.njk`. App ID `2D083718-D442-4A8E-B797-68F24ADD0C7E`. Auto-pageview plus the custom `App.Referral` signal (see `main.js` and `docs/track-app-referrals-plan.md`). Dashboard query recipes live in `docs/telemetrydeck-queries.md`; current signal schema is exported to `docs/iboalali-com-StructuralData.json` and reference TQL syntax is at `docs/TQL-Guideline-v0.1.0.md`
 - **Site footer:** `_includes/main_layout.njk` renders a "View this site's source on GitHub" link below `<main>`
@@ -34,12 +34,20 @@ There are no test or lint scripts configured.
 
 ## Theming
 
-CSS uses custom properties (defined on `:root` in `media/styles.css`) for all theme-dependent colors. The toggle button cycles through three modes — **light → dark → auto** — and theming works via:
+CSS uses custom properties (defined on `:root` in `media/styles.css`) for all theme-dependent colors. The toggle button cycles through four modes — **light → dark → paper → auto** — and theming works via:
 1. **OS preference** — `@media (prefers-color-scheme: dark)` overrides variables when no user choice is stored (auto mode)
-2. **Explicit toggle** — `[data-theme="dark"]` / `[data-theme="light"]` on `<html>` for light/dark; in auto mode the attribute is *removed* so OS preference takes over
+2. **Explicit toggle** — `[data-theme="dark"]` / `[data-theme="light"]` / `[data-theme="paper"]` on `<html>`; in auto mode the attribute is *removed* so OS preference takes over
 3. **Persistence** — `localStorage.getItem('theme')` is applied in an inline `<script>` in `<head>` before paint to prevent flash; auto mode clears the key
 
 Key variables: `--bg`, `--text`, `--accent`, `--border`, `--shadow-accent`. Light accent is `#B37FDF` (purple), dark accent is `#9adefe` (blue). When adding new themed elements, use these variables rather than hardcoded colors.
+
+**Paper** is an e-ink-friendly mode: warm paper background, ink-colored accent, grayscale images, and *all* motion flattened — `* { animation/transition: none !important }` rules at the bottom of `styles.css`, plus separate `::view-transition-*` overrides (the `*` selector doesn't match those pseudo-elements) so navigations are instant page swaps.
+
+## View Transitions & Motion
+
+- **Cross-document view transitions** (`@view-transition { navigation: auto }` in `styles.css`) morph shared elements between pages as progressive enhancement — unsupported browsers navigate normally. Two shared elements: the **profile photo** (home ↔ about; appears once per page, so a static `view-transition-name` in CSS suffices) and the **app icon** (home ↔ app detail; the home page has several icons, so `main.js` tags the one involved in the current navigation from `pageswap`/`pagereveal`)
+- **Entry reveals are suppressed during transitions:** the `fadein`/`about-reveal` load-in animations double as loading animations and must not replay while shared elements morph. An inline head script in `main_layout.njk` toggles `html.via-vt` from `pagereveal`; `styles.css` disables the reveals under that class. The listener must live in the inline head script (not `main.js`, which loads at end of body) because `pagereveal` fires before first render on fresh loads
+- **Reduced motion:** `@media (prefers-reduced-motion: reduce)` makes interaction animations near-instant (tiny durations so `animationend`/`transitionend` still fire) and silences `::view-transition-*` separately, same caveat as Paper
 
 ## Custom Shortcodes (defined in .eleventy.js)
 

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -18,6 +18,15 @@ title: Ibrahim Al-Alali
             (function() {
                 var t = localStorage.getItem('theme');
                 if (t === 'light' || t === 'dark' || t === 'paper') document.documentElement.setAttribute('data-theme', t);
+
+                // Must be registered before first render: pagereveal fires before
+                // main.js (end of body) runs on fresh loads. When the page is
+                // revealed via a view transition, the morph/crossfade is the entry
+                // animation — html.via-vt (styles.css) suppresses the load-in
+                // reveals so shared elements don't fade while they morph.
+                window.addEventListener('pagereveal', function (e) {
+                    document.documentElement.classList.toggle('via-vt', !!e.viewTransition);
+                });
             })();
         </script>
         <link rel="icon" type="image/png" href="/media/icon_x32.png" sizes="32x32">

--- a/main.js
+++ b/main.js
@@ -135,3 +135,50 @@ document.querySelectorAll('main a').forEach(function (linkEl) {
         }, 100);
     }
 })();
+
+// Shared-element view transition for the app icon. On the home page each app
+// card has a .app-icon; the detail page's single .app-hero-icon statically owns
+// the shared name "app-icon" (see styles.css). Here we assign that same name to
+// the *one* home-page icon involved in the current navigation so the browser
+// morphs it into / out of the hero. No-ops when the browser lacks support.
+;(function () {
+    function normalize(path) {
+        return path.replace(/\/+$/, '');
+    }
+
+    function clearIcons() {
+        document.querySelectorAll('.app-item .app-icon').forEach(function (icon) {
+            icon.style.viewTransitionName = '';
+        });
+    }
+
+    // Tag the home-page icon whose card links to the given URL.
+    function tagIcon(urlStr) {
+        if (!urlStr) return;
+        var targetPath = normalize(new URL(urlStr, location.href).pathname);
+        document.querySelectorAll('.app-item').forEach(function (item) {
+            var link = item.querySelector('a[href]');
+            var icon = item.querySelector('.app-icon');
+            if (!link || !icon) return;
+            if (normalize(new URL(link.href).pathname) === targetPath) {
+                icon.style.viewTransitionName = 'app-icon';
+            }
+        });
+    }
+
+    // Forward navigation (home -> detail): tag the icon for the destination.
+    window.addEventListener('pageswap', function (e) {
+        if (!e.viewTransition) return;
+        clearIcons();
+        if (e.activation && e.activation.entry) tagIcon(e.activation.entry.url);
+    });
+
+    // Back navigation (detail -> home): tag the icon for where we came from.
+    window.addEventListener('pagereveal', function (e) {
+        if (!e.viewTransition) return;
+        clearIcons();
+        if (window.navigation && navigation.activation && navigation.activation.from) {
+            tagIcon(navigation.activation.from.url);
+        }
+    });
+})();

--- a/main.js
+++ b/main.js
@@ -174,6 +174,8 @@ document.querySelectorAll('main a').forEach(function (linkEl) {
     });
 
     // Back navigation (detail -> home): tag the icon for where we came from.
+    // (The html.via-vt reveal-suppression toggle lives in the inline head
+    // script in main_layout.njk — it must register before first render.)
     window.addEventListener('pagereveal', function (e) {
         if (!e.viewTransition) return;
         clearIcons();

--- a/media/styles.css
+++ b/media/styles.css
@@ -1,5 +1,22 @@
 /* Animations */
 
+/* Cross-document view transitions: morph the app icon between the home list
+   and the app detail hero on same-origin navigations. Browsers without support
+   ignore this at-rule and the view-transition-name property below and navigate
+   normally — pure progressive enhancement. */
+@view-transition {
+    navigation: auto;
+}
+
+/* Respect users who prefer reduced motion: make the transition instant. */
+@media (prefers-reduced-motion: reduce) {
+    ::view-transition-group(*),
+    ::view-transition-old(*),
+    ::view-transition-new(*) {
+        animation: none !important;
+    }
+}
+
 @keyframes fadein {
 	from {
 		transform: translateY(-10px);
@@ -572,6 +589,10 @@ a.btn-container img:hover {
 }
 
 .app-hero-icon {
+    /* Shared element for the cross-document view transition (paired with the
+       matching .app-icon on the home page, tagged at navigation time in main.js).
+       Only one hero icon exists per detail page, so a static name is safe. */
+    view-transition-name: app-icon;
     width: 140px;
     height: 140px;
     border-radius: 28%;

--- a/media/styles.css
+++ b/media/styles.css
@@ -992,6 +992,18 @@ a.btn-container img:hover {
     filter: grayscale(1);
 }
 
+/* The * rules above don't reach ::view-transition-* pseudo-elements (same
+   caveat as the reduced-motion block at the top of this file), so silence the
+   cross-document morph/crossfade separately: with no animations the view
+   transition finishes instantly. The new page applies data-theme from
+   localStorage in a pre-render inline head script, so the attribute is in
+   place before the transition's pseudo-elements animate. */
+:root[data-theme="paper"]::view-transition-group(*),
+:root[data-theme="paper"]::view-transition-old(*),
+:root[data-theme="paper"]::view-transition-new(*) {
+    animation: none !important;
+}
+
 /* Disable animations on user request */
 
 /* Honor the OS-level reduced-motion preference across every animation and

--- a/media/styles.css
+++ b/media/styles.css
@@ -973,29 +973,20 @@ a.btn-container img:hover {
 
 /* Disable animations on user request */
 
+/* Honor the OS-level reduced-motion preference across every animation and
+   interaction transition (entry reveals, hover lifts, button/link transitions).
+   Near-instant durations rather than 0 so animationend/transitionend listeners
+   still fire. The view-transition morphs are handled separately near the top of
+   this file, since ::view-transition-* pseudo-elements aren't matched by *. */
 @media (prefers-reduced-motion: reduce) {
 
-    main {
-        animation: none !important;
-    }
-
-    a {
-        transition: 0ms !important;
-    }
-
-    .home-hero,
-    .home-section-title,
-    .app-item,
-    .about-hero,
-    .about-bio,
-    .about-actions,
-    .contact-hero,
-    .contact-links,
-    .app-back-link,
-    .app-hero,
-    .app-content,
-    .whats-new {
-        animation: none !important;
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
     }
 
 }

--- a/media/styles.css
+++ b/media/styles.css
@@ -17,6 +17,27 @@
     }
 }
 
+/* When the page is revealed via a view transition, the morph/crossfade IS the
+   entry animation — suppress the load-in reveals (fadein on main, about-reveal
+   on heroes/cards) so shared elements don't fade/slide while they morph.
+   main.js toggles .via-vt on <html> from the pagereveal event; browsers without
+   cross-document view transitions never set it and animate normally. */
+html.via-vt main,
+html.via-vt .home-hero,
+html.via-vt .home-section-title,
+html.via-vt .app-item,
+html.via-vt .contact-hero,
+html.via-vt .contact-links,
+html.via-vt .about-hero,
+html.via-vt .about-bio,
+html.via-vt .about-actions,
+html.via-vt .app-back-link,
+html.via-vt .app-hero,
+html.via-vt .app-content,
+html.via-vt .whats-new {
+    animation: none;
+}
+
 @keyframes fadein {
 	from {
 		transform: translateY(-10px);

--- a/media/styles.css
+++ b/media/styles.css
@@ -222,6 +222,10 @@ a.btn-container img:hover {
 }
 
 .profile-photo {
+    /* Shared element for the cross-document view transition: morphs between the
+       home hero and the about hero. The photo appears exactly once per page, so
+       a static name is safe (no JS coordination needed, unlike .app-icon). */
+    view-transition-name: profile-photo;
     float: right;
     border-radius: 50%;
     width: 25%;


### PR DESCRIPTION
Morph the app icon between the home page list and the app detail hero
using cross-document (MPA) view transitions:

- Opt in with @view-transition { navigation: auto } and give the single
  detail-page .app-hero-icon a static view-transition-name.
- Coordinate the home page in main.js: tag only the icon involved in the
  current navigation (forward via pageswap, back via pagereveal) so the
  other cards don't ghost during the transition.
- Add a prefers-reduced-motion guard.

Pure progressive enhancement: unsupported browsers ignore the rules and
navigate normally.

https://claude.ai/code/session_01XDPKXPLUQow4JJGXWqniZ5