### PR TITLE
Fix paper-mode nav hover rendering text dark-on-dark

### DIFF
--- a/media/styles.css
+++ b/media/styles.css
@@ -992,6 +992,16 @@ a.btn-container img:hover {
     filter: grayscale(1);
 }
 
+/* The nav buttons are a hardcoded dark grey in every theme, and the default
+   hover recolors the label to var(--accent). In paper that accent is dark ink,
+   so the text would all but vanish into the button. Keep the label light and
+   signal hover by lightening the button instead. */
+:root[data-theme="paper"] nav ul li a:hover {
+    color: #FFF;
+    background: #5A5A5A;
+    filter: none;
+}
+
 /* The * rules above don't reach ::view-transition-* pseudo-elements (same
    caveat as the reduced-motion block at the top of this file), so silence the
    cross-document morph/crossfade separately: with no animations the view


### PR DESCRIPTION
In paper mode --accent is dark ink (#3A3A3A), nearly matching the nav buttons' hardcoded #424242 background, so the default hover (which recolors the label to var(--accent)) made the text vanish. Add a paper-specific hover that keeps the label white and lightens the button for feedback.