### PR TITLE
Auto-adopt Paper theme on e-ink readers in auto mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,8 @@ Key variables: `--bg`, `--text`, `--accent`, `--border`, `--shadow-accent`. Ligh
 
 **Paper** is an e-ink-friendly mode: warm paper background, ink-colored accent, grayscale images, and *all* motion flattened — `* { animation/transition: none !important }` rules at the bottom of `styles.css`, plus separate `::view-transition-*` overrides (the `*` selector doesn't match those pseudo-elements) so navigations are instant page swaps.
 
+**E-ink auto-detection:** in auto mode (no stored preference), e-ink readers automatically get the Paper theme. The pre-paint head script in `main_layout.njk` detects them via `matchMedia('(update: slow)')` (the standards signal for e-ink's slow refresh) plus a UA allowlist of dedicated reader brands (Kindle, Kobo, PocketBook, Tolino, Bookeen, BOOX, reMarkable, NOOK) for browsers predating that media feature. On a match it adds `html.eink-paper` — *not* `data-theme`, so the mode stays "auto" (the toggle keeps working and cycling back to auto re-applies paper). Each Paper rule in `styles.css` carries a parallel `:root.eink-paper:not([data-theme])` selector; the `:not([data-theme])` guard means any explicit toggle choice still overrides the auto-detected paper.
+
 ## View Transitions & Motion
 
 - **Cross-document view transitions** (`@view-transition { navigation: auto }` in `styles.css`) morph shared elements between pages as progressive enhancement — unsupported browsers navigate normally. Two shared elements: the **profile photo** (home ↔ about; appears once per page, so a static `view-transition-name` in CSS suffices) and the **app icon** (home ↔ app detail; the home page has several icons, so `main.js` tags the one involved in the current navigation from `pageswap`/`pagereveal`)

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -36,7 +36,22 @@ title: Ibrahim Al-Alali
         <script>
             (function() {
                 var t = localStorage.getItem('theme');
-                if (t === 'light' || t === 'dark' || t === 'paper') document.documentElement.setAttribute('data-theme', t);
+                if (t === 'light' || t === 'dark' || t === 'paper') {
+                    document.documentElement.setAttribute('data-theme', t);
+                } else {
+                    // No explicit choice (auto mode): adopt the Paper theme on
+                    // e-ink readers. `update: slow` is the standards signal for
+                    // e-ink's slow refresh; the UA list catches dedicated readers
+                    // whose browsers predate it. We set a class rather than
+                    // data-theme so the mode stays "auto" — the toggle keeps
+                    // working, and styles.css applies paper via
+                    // .eink-paper:not([data-theme]) (so any explicit choice wins).
+                    try {
+                        var eink = (window.matchMedia && window.matchMedia('(update: slow)').matches)
+                            || /Kindle|Kobo|PocketBook|Tolino|Bookeen|BOOX|reMarkable|\bNOOK\b|BNRV/i.test(navigator.userAgent || '');
+                        if (eink) document.documentElement.classList.add('eink-paper');
+                    } catch (e) { /* matchMedia/UA unavailable — skip detection */ }
+                }
 
                 // Must be registered before first render: pagereveal fires before
                 // main.js (end of body) runs on fresh loads. When the page is

--- a/media/styles.css
+++ b/media/styles.css
@@ -101,7 +101,11 @@ html.via-vt .whats-new {
     --muted: #999;
 }
 
-:root[data-theme="paper"] {
+/* Paper variables also apply automatically on e-ink readers in auto mode,
+   where the head script tags <html> with .eink-paper. The :not([data-theme])
+   guard means any explicit toggle choice (including paper itself) still wins. */
+:root[data-theme="paper"],
+:root.eink-paper:not([data-theme]) {
     --bg: #F4F1EA;            /* warm paper */
     --text: #1A1A1A;          /* near-black ink */
     --text-on-accent: #F4F1EA;
@@ -987,14 +991,18 @@ a.btn-container img:hover {
 
 :root[data-theme="paper"] *,
 :root[data-theme="paper"] *::before,
-:root[data-theme="paper"] *::after {
+:root[data-theme="paper"] *::after,
+:root.eink-paper:not([data-theme]) *,
+:root.eink-paper:not([data-theme]) *::before,
+:root.eink-paper:not([data-theme]) *::after {
     box-shadow: none !important;
     text-shadow: none !important;
     animation: none !important;
     transition: none !important;
 }
 
-:root[data-theme="paper"] img {
+:root[data-theme="paper"] img,
+:root.eink-paper:not([data-theme]) img {
     filter: grayscale(1);
 }
 
@@ -1002,7 +1010,8 @@ a.btn-container img:hover {
    hover recolors the label to var(--accent). In paper that accent is dark ink,
    so the text would all but vanish into the button. Keep the label light and
    signal hover by lightening the button instead. */
-:root[data-theme="paper"] nav ul li a:hover {
+:root[data-theme="paper"] nav ul li a:hover,
+:root.eink-paper:not([data-theme]) nav ul li a:hover {
     color: #FFF;
     background: #5A5A5A;
     filter: none;
@@ -1016,7 +1025,10 @@ a.btn-container img:hover {
    place before the transition's pseudo-elements animate. */
 :root[data-theme="paper"]::view-transition-group(*),
 :root[data-theme="paper"]::view-transition-old(*),
-:root[data-theme="paper"]::view-transition-new(*) {
+:root[data-theme="paper"]::view-transition-new(*),
+:root.eink-paper:not([data-theme])::view-transition-group(*),
+:root.eink-paper:not([data-theme])::view-transition-old(*),
+:root.eink-paper:not([data-theme])::view-transition-new(*) {
     animation: none !important;
 }
 


### PR DESCRIPTION
In auto mode (no stored theme), detect e-ink readers and apply the Paper theme automatically. The pre-paint head script detects them via matchMedia('(update: slow)') — the standards signal for e-ink's slow refresh — plus a UA allowlist of dedicated reader brands (Kindle, Kobo, PocketBook, Tolino, Bookeen, BOOX, reMarkable, NOOK) for browsers that predate that media feature.

On a match it adds html.eink-paper rather than data-theme, so the mode stays "auto": the toggle keeps working and cycling back to auto re-applies paper. Each Paper rule in styles.css gains a parallel :root.eink-paper:not([data-theme]) selector; the :not([data-theme]) guard lets any explicit toggle choice override the auto-detected paper.

Generic Amazon Silk is intentionally excluded from the UA list since it also runs on color Fire tablets; update:slow handles the e-ink-vs-LCD distinction for modern devices.