### PR TITLE
Announce free + IAP transition in Hide Persistent Notification What's…

### DIFF
--- a/app/hide_persistent_notification.md
+++ b/app/hide_persistent_notification.md
@@ -8,6 +8,7 @@ tagline: Pick a persistent notification and keep it hidden for as long as the ap
 ---
 
 {% whatsNew %}
+- **Heads up: the app is going free with an optional in-app purchase.** If you already bought it, open the Settings screen and sign in so your purchase carries over and you keep every premium feature for free, no second purchase needed.
 - Completely rewritten with modern technologies
 - In-app updates: install the latest version right from the app
 - Support for Android 17


### PR DESCRIPTION
… New

Tell existing paying users the app is becoming free with an optional in-app purchase, and that signing in via the Settings screen carries their purchase over so they keep premium features at no cost.