### PR TITLE
Give per-app privacy pages an app-specific social card

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -79,6 +79,18 @@ module.exports = function (eleventyConfig) {
         return `<a href="${link}" class="btn-container" target="_blank" rel="noopener"><img src="/media/github_badge.svg" alt="${alt}" /></a>`;
     });
 
+    // For a per-app privacy page (/app/<slug>/privacy/), find the sibling app
+    // detail page (/app/<slug>/) so the social-graph card can reuse the app's
+    // own name/tagline instead of the generic developer description. Returns the
+    // matching collection item, or null. Driven off collections (available in
+    // templates, unlike eleventyComputed) so it never drifts from the app page
+    // frontmatter — the same source the apps.json feed uses.
+    eleventyConfig.addFilter("appPageForPrivacy", function (all, url) {
+        if (!url || url === "/privacy/" || !url.endsWith("/privacy/")) return null;
+        const appUrl = url.replace(/privacy\/$/, "");
+        return (all || []).find((p) => p.url === appUrl && p.data.appName) || null;
+    });
+
     // `data-contact` carries the platform name so the click telemetry in main.js
     // identifies the card without parsing its (potentially localized) link text.
     eleventyConfig.addShortcode("socials", function (name, link, icon) {

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -7,13 +7,20 @@ title: Ibrahim Al-Alali
   - Generic defaults apply to every page.
   - App detail pages carry an `icon` (and `tagline`/`appName`) in their
     frontmatter, so the card automatically uses the app icon and tagline.
+  - Per-app privacy pages (/app/<slug>/privacy/) reuse the sibling app page's
+    icon and tagline (the app name is already in the title), so the card is
+    branded for the app instead of falling back to the generic profile defaults.
   - Any page may override `description` in its frontmatter.
 #}
-{%- set ogDescription = description or tagline or "Ibrahim Al-Alali is an Android app software developer" -%}
+{%- set privacyApp = collections.all | appPageForPrivacy(page.url) -%}
+{%- set privacyTagline = privacyApp.data.tagline if privacyApp else "" -%}
+{%- set ogDescription = description or privacyTagline or tagline or "Ibrahim Al-Alali is an Android app software developer" -%}
 {%- set ogUrl = siteUrl + page.url -%}
-{%- if icon -%}
-    {%- set ogImage = siteUrl + "/media/" + icon -%}
-    {%- set ogImageAlt = appName + " app icon" -%}
+{%- set cardIcon = icon or (privacyApp.data.icon if privacyApp else "") -%}
+{%- set cardAppName = appName or (privacyApp.data.appName if privacyApp else "") -%}
+{%- if cardIcon -%}
+    {%- set ogImage = siteUrl + "/media/" + cardIcon -%}
+    {%- set ogImageAlt = cardAppName + " app icon" -%}
     {%- set ogImageSize = "256" -%}
 {%- else -%}
     {%- set ogImage = siteUrl + "/media/profile.jpg" -%}


### PR DESCRIPTION
The per-app privacy pages (/app/<slug>/privacy/) only declare a layout and title, so the social-graph card fell back to the generic developer description and profile photo. The app name was already in the page title, but the description and image were generic.

Add an `appPageForPrivacy` filter that maps a privacy page URL to its sibling app detail page via collections, and reuse that app's tagline and icon as the card description and image in main_layout.njk. Collections are read in the template (not eleventyComputed, where they're empty during the data cascade), so the card always tracks the app page frontmatter without duplication — the same single-source-of-truth approach the apps.json feed uses.

Non-privacy pages and the top-level /privacy/ page are unaffected.