### PR TITLE
Fix Google Search Console indexing issues

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,4 +1,5 @@
 CLAUDE.md
+README.md
 docs/
 DOMAIN_SETUP.md
 .claude/

--- a/404.md
+++ b/404.md
@@ -2,6 +2,7 @@
 layout: main_layout.njk
 title: Page Not Found
 permalink: "404.html"
+noindex: true
 ---
 
 ## The page isn't available

--- a/_includes/main_layout.njk
+++ b/_includes/main_layout.njk
@@ -34,7 +34,11 @@ title: Ibrahim Al-Alali
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>{{ title }}</title>
         <meta name="description" content="{{ ogDescription }}">
+        {%- if noindex %}
+        <meta name="robots" content="noindex">
+        {%- else %}
         <link rel="canonical" href="{{ ogUrl }}">
+        {%- endif %}
         <meta name="viewport" content="width=device-width, initial-scale=1.0">    
         <meta name="keywords" content="ibrahim, al-alali, ibrahim al-alali, alali, ibo, apps, app, play store, notification, java, kotlin">
         <meta name="language" content="English">
@@ -97,13 +101,13 @@ title: Ibrahim Al-Alali
                     {% if page.url == "/" %}<span class="nav-current">Home</span>{% else %}<a href="/">Home</a>{% endif %}
                 </li>
                 <li>
-                    {% if page.url == "/about/" %}<span class="nav-current">About</span>{% else %}<a href="/about">About</a>{% endif %}
+                    {% if page.url == "/about/" %}<span class="nav-current">About</span>{% else %}<a href="/about/">About</a>{% endif %}
                 </li>
                 <li>
-                    {% if page.url == "/contact/" %}<span class="nav-current">Contact</span>{% else %}<a href="/contact">Contact</a>{% endif %}
+                    {% if page.url == "/contact/" %}<span class="nav-current">Contact</span>{% else %}<a href="/contact/">Contact</a>{% endif %}
                 </li>
                 <li>
-                    {% if page.url == "/privacy/" %}<span class="nav-current">Privacy</span>{% else %}<a href="/privacy">Privacy</a>{% endif %}
+                    {% if page.url == "/privacy/" %}<span class="nav-current">Privacy</span>{% else %}<a href="/privacy/">Privacy</a>{% endif %}
                 </li>
             </ul>
         </nav>

--- a/about.md
+++ b/about.md
@@ -20,5 +20,5 @@ I work for [Blueworld GmbH](https://www.blueworld-gmbh.de/) developing a B2B tel
 <div class="about-actions">
 <a href="/" class="about-btn">My Apps</a>
 <a href="https://play.google.com/store/apps/dev?id=7518575784939651133" class="about-btn">Play Store</a>
-<a href="/contact" class="about-btn about-btn-primary">Get in Touch</a>
+<a href="/contact/" class="about-btn about-btn-primary">Get in Touch</a>
 </div>

--- a/home.njk
+++ b/home.njk
@@ -1,0 +1,24 @@
+---
+# Redirect stub for the legacy /home URL (from the old Tumblr blog) → homepage.
+# Google had /home in the "Not found (404)" report; this makes it resolve and
+# consolidates any link equity onto "/". Output is /home.html, which GitHub
+# Pages serves for a request to /home. Excluded from collections so it never
+# lands in the sitemap or the apps feed. Uses the canonical + meta-refresh +
+# JS + noindex pattern that jekyll-redirect-from emits.
+permalink: "home.html"
+eleventyExcludeFromCollections: true
+---
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <title>Redirecting…</title>
+        <link rel="canonical" href="{{ siteUrl }}/">
+        <script>location.replace("{{ siteUrl }}/")</script>
+        <meta http-equiv="refresh" content="0; url={{ siteUrl }}/">
+        <meta name="robots" content="noindex">
+    </head>
+    <body>
+        <p>This page has moved. <a href="{{ siteUrl }}/">Continue to iboalali.com</a>.</p>
+    </body>
+</html>

--- a/privacy.md
+++ b/privacy.md
@@ -22,4 +22,4 @@ This site is hosted on GitHub Pages. GitHub may log standard request metadata (s
 
 {% heading "Contact", "contact" %}
 
-Questions about this policy? [Get in touch](/contact).
+Questions about this policy? [Get in touch](/contact/).

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://iboalali.com/sitemap.xml

--- a/sitemap.11ty.js
+++ b/sitemap.11ty.js
@@ -1,0 +1,38 @@
+// Generates /sitemap.xml listing the site's canonical, indexable HTML pages so
+// Google can discover them and pick the right canonical. Built from
+// collections.all: every page whose URL ends in "/" (the HTML pages) that isn't
+// marked `noindex`. That filter naturally excludes the JSON feeds (/apps*.json,
+// whose URLs don't end in "/"), the 404 page (noindex: true), and the sitemap
+// itself (eleventyExcludeFromCollections). robots.txt points crawlers here.
+//
+// No <lastmod>: GitHub Actions checks out fresh, so file mtimes all equal the
+// build time and would make every lastmod identical (and useless). Omitting it
+// is valid and avoids feeding Google misleading dates.
+module.exports = class {
+    data() {
+        return {
+            permalink: "/sitemap.xml",
+            eleventyExcludeFromCollections: true,
+        };
+    }
+
+    render(data) {
+        const { collections, siteUrl } = data;
+
+        const urls = collections.all
+            .filter((item) => item.url && item.url.endsWith("/") && !item.data.noindex)
+            .map((item) => `${siteUrl}${item.url}`)
+            .sort();
+
+        const entries = urls
+            .map((loc) => `  <url>\n    <loc>${loc}</loc>\n  </url>`)
+            .join("\n");
+
+        return (
+            `<?xml version="1.0" encoding="UTF-8"?>\n` +
+            `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+            `${entries}\n` +
+            `</urlset>\n`
+        );
+    }
+};


### PR DESCRIPTION
- Generate /sitemap.xml (canonical HTML URLs) and point robots.txt at it
- Stop publishing README.md as a /README/ page
- noindex the 404 page and drop its self-canonical; add generic noindex frontmatter support in main_layout
- Use trailing-slash internal links so they match the canonical URLs (nav, about, privacy) and avoid an extra redirect hop
- Add a /home -> homepage redirect stub for the legacy Tumblr URL